### PR TITLE
feat: SQLite implementation of `DialectProvider`

### DIFF
--- a/light-core/src/main/java/space/lingu/light/LightConfiguration.java
+++ b/light-core/src/main/java/space/lingu/light/LightConfiguration.java
@@ -42,21 +42,21 @@ public @interface LightConfiguration {
      *
      * @see space.lingu.light.sql.MySQLDialectProvider#DEFAULT_VARCHAR_LENGTH
      */
-    String KEY_VARCHAR_LENGTH = "Light.Key.VarcharLength";
+    String KEY_VARCHAR_LENGTH = "Key.Light.VarcharLength";
 
     /**
      * charset configuration
      *
      * @see space.lingu.light.sql.MySQLDialectProvider#DEFAULT_CHARSET
      */
-    String KEY_CHARSET = "Light.Key.Charset";
+    String KEY_CHARSET = "Key.Light.Charset";
 
     /**
      * Engine configuration
      *
      * @see space.lingu.light.sql.MySQLDialectProvider#DEFAULT_ENGINE
      */
-    String KEY_ENGINE = "Light.Key.Engine";
+    String KEY_ENGINE = "Key.Light.Engine";
 
     /**
      * Custom column type.
@@ -72,6 +72,6 @@ public @interface LightConfiguration {
      * Compare to {@link #KEY_VARCHAR_LENGTH}, this configuration contains more
      * fine-grained control.
      */
-    String KEY_COLUMN_TYPE = "Light.Key.ColumnType";
+    String KEY_COLUMN_TYPE = "Key.Light.ColumnType";
 
 }

--- a/light-core/src/main/java/space/lingu/light/PrimaryKey.java
+++ b/light-core/src/main/java/space/lingu/light/PrimaryKey.java
@@ -30,7 +30,10 @@ public @interface PrimaryKey {
     /**
      * Whether to automatically generate the primary key.
      * <p>
-     * If you are define composite primary key, this will not work.
+     * If you are defining a composite primary key,
+     * this will not work and will simply be ignored
+     * (whether to ignore or throw an Exception is related to the different
+     * {@link space.lingu.light.sql.DialectProvider}'s strategy).
      *
      * @return If automatically generate or not.
      */

--- a/light-core/src/main/java/space/lingu/light/sql/GeneralDialectProvider.java
+++ b/light-core/src/main/java/space/lingu/light/sql/GeneralDialectProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022 Lingu Light Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package space.lingu.light.sql;
+
+import space.lingu.light.Configurations;
+import space.lingu.light.SQLDataType;
+import space.lingu.light.struct.TableColumn;
+
+/**
+ * @author RollW
+ */
+public abstract class GeneralDialectProvider extends AsciiSQLGenerator
+        implements DialectProvider, SQLGenerator {
+
+    protected String createColumn(TableColumn column) {
+        StringBuilder builder = new StringBuilder(escapeParam(column.getName()))
+                .append(" ");
+        final String nonNull = column.isNullable()
+                ? ""
+                : " " + notNullDeclare();
+        builder.append(getDefaultTypeDeclaration(column.getDataType(),
+                        column.getConfigurations()))
+                .append(nonNull);
+        if (column.isAutoGenerate()) {
+            builder.append(" ").append(autoIncrementDeclare());
+        }
+        if (column.isHasDefaultValue()) {
+            builder.append(" DEFAULT");
+            if (column.isDefaultValueNull()) {
+                builder.append(" NULL");
+            } else {
+                builder.append(" ")
+                        .append(column.getDefaultValueWithProcess());
+            }
+        }
+
+        return builder.toString();
+    }
+
+    protected abstract String notNullDeclare();
+
+    protected abstract String autoIncrementDeclare();
+
+    protected abstract String getDefaultTypeDeclaration(SQLDataType dataType,
+                                                        Configurations configurations);
+
+
+}

--- a/light-core/src/main/java/space/lingu/light/sql/GeneralDialectProvider.java
+++ b/light-core/src/main/java/space/lingu/light/sql/GeneralDialectProvider.java
@@ -26,7 +26,7 @@ import space.lingu.light.struct.TableColumn;
 public abstract class GeneralDialectProvider extends AsciiSQLGenerator
         implements DialectProvider, SQLGenerator {
 
-    protected String createColumn(TableColumn column) {
+    protected String createColumn(TableColumn column, boolean isPrimaryKey) {
         StringBuilder builder = new StringBuilder(escapeParam(column.getName()))
                 .append(" ");
         final String nonNull = column.isNullable()
@@ -35,6 +35,9 @@ public abstract class GeneralDialectProvider extends AsciiSQLGenerator
         builder.append(getDefaultTypeDeclaration(column.getDataType(),
                         column.getConfigurations()))
                 .append(nonNull);
+        if (isPrimaryKey) {
+            builder.append(" ").append(primaryKeyDeclare());
+        }
         if (column.isAutoGenerate()) {
             builder.append(" ").append(autoIncrementDeclare());
         }
@@ -49,6 +52,14 @@ public abstract class GeneralDialectProvider extends AsciiSQLGenerator
         }
 
         return builder.toString();
+    }
+
+    protected String createColumn(TableColumn column) {
+        return createColumn(column, false);
+    }
+
+    protected String primaryKeyDeclare() {
+        return "PRIMARY KEY";
     }
 
     protected abstract String notNullDeclare();

--- a/light-core/src/main/java/space/lingu/light/sql/MySQLDialectProvider.java
+++ b/light-core/src/main/java/space/lingu/light/sql/MySQLDialectProvider.java
@@ -57,14 +57,14 @@ public class MySQLDialectProvider extends GeneralDialectProvider
 
         String autoIncrementStart = null;
         StringJoiner primaryKeyJoiner = new StringJoiner(", ");
-        for (TableColumn column : table.getPrimaryKey().columns) {
+        for (TableColumn column : table.getPrimaryKey().getColumns()) {
             if (column.isHasDefaultValue()) {
                 autoIncrementStart = column.getDefaultValue();
             }
             primaryKeyJoiner.add(escapeParam(column.getName()));
         }
         builder.append(columnJoiner);
-        if (!table.getPrimaryKey().columns.isEmpty()) {
+        if (!table.getPrimaryKey().getColumns().isEmpty()) {
             builder.append(", PRIMARY KEY (")
                     .append(primaryKeyJoiner)
                     .append(") ");

--- a/light-core/src/main/java/space/lingu/light/sql/SQLiteDialectProvider.java
+++ b/light-core/src/main/java/space/lingu/light/sql/SQLiteDialectProvider.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2022 Lingu Light Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package space.lingu.light.sql;
+
+import space.lingu.light.*;
+import space.lingu.light.struct.DatabaseInfo;
+import space.lingu.light.struct.Table;
+import space.lingu.light.struct.TableColumn;
+import space.lingu.light.struct.TableIndex;
+import space.lingu.light.util.StringUtil;
+
+import java.util.StringJoiner;
+
+/**
+ * SQLite Dialect Provider.
+ *
+ * @author RollW
+ */
+public class SQLiteDialectProvider extends GeneralDialectProvider
+        implements DialectProvider, SQLGenerator {
+
+    /**
+     * Enable strict mode on the table.
+     * <p>
+     * Needs to be a boolean value. If {@code true} enable it.
+     * Disabled by default.
+     */
+    public static final String KEY_ENABLE_STRICT = "Key.SQLite.Strict";
+
+
+    @Override
+    public String create(Table table) {
+        StringBuilder builder = new StringBuilder("CREATE TABLE IF NOT EXISTS ")
+                .append(escapeParam(table.getName()))
+                .append(" (");
+        StringJoiner columnJoiner = new StringJoiner(", ");
+        table.getColumns().forEach(column ->
+                columnJoiner.add(createColumn(column)));
+
+        StringJoiner primaryKeyJoiner = new StringJoiner(", ");
+        for (TableColumn column : table.getPrimaryKey().columns) {
+            primaryKeyJoiner.add(escapeParam(column.getName()));
+        }
+        builder.append(columnJoiner);
+        if (!table.getPrimaryKey().columns.isEmpty()) {
+            builder.append(", PRIMARY KEY (")
+                    .append(primaryKeyJoiner)
+                    .append(") ");
+        }
+
+        builder.append(") ");
+        Configurations.Configuration strictConfig =
+                table.getConfigurations().findConfiguration(KEY_ENABLE_STRICT);
+        if (strictConfig != null && strictConfig.toBoolean()) {
+            builder.append("STRICT ");
+        }
+
+        return builder.toString();
+    }
+
+
+    @Override
+    protected String notNullDeclare() {
+        return "NOT NULL";
+    }
+
+    @Override
+    protected String autoIncrementDeclare() {
+        return "AUTOINCREMENT";
+    }
+
+    @Override
+    protected String getDefaultTypeDeclaration(SQLDataType dataType,
+                                               Configurations configurations) {
+        if (dataType == null) {
+            throw new IllegalArgumentException("SQLDataType is null. " +
+                    "This may be a Light bug, please report it to us.");
+        }
+        String type = configurations.findConfigurationValue(
+                LightConfiguration.KEY_COLUMN_TYPE);
+        if (!StringUtil.isEmpty(type)) {
+            return type;
+        }
+
+        switch (dataType) {
+            case CHAR:
+            case INT:
+            case TINYINT:
+            case SMALLINT:
+            case LONG:
+                return "INTEGER";
+            case BOOLEAN:
+                return "BOOLEAN";
+            case FLOAT:
+            case DOUBLE:
+            case REAL:
+                return "REAL";
+            case CHARS:
+            case VARCHAR:
+            case LONGTEXT:
+            case TEXT:
+                return "TEXT";
+            case BINARY:
+                return "BLOB";
+            default:
+                throw new IllegalArgumentException("SQLDataType is undefined. " +
+                        "This may be a Light bug, please report it to us.");
+        }
+    }
+
+    @Override
+    public String create(TableIndex index) {
+        StringBuilder builder = new StringBuilder("CREATE");
+        if (index.isUnique()) {
+            builder.append(" UNIQUE");
+        }
+        builder.append(" INDEX IF NOT EXISTS ")
+                .append(escapeParam(index.getName()))
+                .append(" ON ")
+                .append(escapeParam(index.getTableName()))
+                .append(" (");
+        StringJoiner indexColumns = new StringJoiner(", ");
+        String[] columns = index.getColumns();
+        boolean ordersEmpty = index.getOrders().length == 0;
+
+        for (int i = 0; i < columns.length; i++) {
+            indexColumns.add(escapeParam(columns[i]) +
+                    (ordersEmpty
+                            ? ""
+                            : " " + getOrderOrDefault(i, index.getOrders())
+                    ));
+        }
+        builder.append(indexColumns).append(") ");
+        return builder.toString();
+    }
+
+    private String getOrderOrDefault(int index, Order[] orders) {
+        try {
+            return orders[index].name();
+        } catch (Exception e) {
+            return Order.ASC.name();
+        }
+    }
+
+    @Override
+    public String drop(Table table) {
+        return "DROP TABLE IF EXISTS " + escapeParam(table.getName());
+    }
+
+    @Override
+    public String create(DatabaseInfo databaseInfo) {
+        // for SQLite, there is no "CREATE DATABASE" like command,
+        // needs to be created a db file manually or automatically
+        // created by sqlite when set up a connection.
+        return null;
+    }
+
+    @Override
+    public String drop(DatabaseInfo databaseInfo) {
+        // also no "DROP DATABASE" like command,
+        // needs to delete database file manually.
+        return null;
+    }
+
+    @Override
+    public String useDatabase(String databaseName) {
+        // the same reason.
+        return null;
+    }
+
+    @Override
+    public String use(DatabaseInfo databaseInfo) {
+        return null;
+    }
+
+    @Override
+    public SQLGenerator getGenerator() {
+        return this;
+    }
+
+    @Override
+    public String insert(String tableName, String... valueArgs) {
+        return insert(tableName, OnConflictStrategy.ABORT, valueArgs);
+    }
+
+    @Override
+    public String insert(String tableName, OnConflictStrategy onConflict, String... valueArgs) {
+        StringBuilder statementBuilder = new StringBuilder();
+        if (onConflict == OnConflictStrategy.REPLACE) {
+            statementBuilder.append("REPLACE");
+        } else {
+            statementBuilder.append("INSERT OR ").append(onConflict.name());
+        }
+
+        return buildInsertWithStart(tableName, statementBuilder.toString(), valueArgs);
+    }
+
+    @Override
+    public String update(String tableName, String[] whereConditions, String[] valueArgs) {
+        return update(tableName, OnConflictStrategy.ABORT, whereConditions, valueArgs);
+    }
+
+    @Override
+    public String update(String tableName, OnConflictStrategy onConflict, String[] whereConditions, String[] valueArgs) {
+        return buildUpdateWithStart(tableName,
+                "UPDATE OR " + onConflict.name(),
+                whereConditions, valueArgs);
+    }
+}

--- a/light-core/src/main/java/space/lingu/light/struct/TablePrimaryKey.java
+++ b/light-core/src/main/java/space/lingu/light/struct/TablePrimaryKey.java
@@ -18,13 +18,14 @@ package space.lingu.light.struct;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author RollW
  */
 public class TablePrimaryKey {
-    public final List<TableColumn> columns;
-    public final boolean autoGenerate;
+    private final List<TableColumn> columns;
+    private final boolean autoGenerate;
 
     public TablePrimaryKey(List<TableColumn> columns, boolean autoGenerate) {
         this.columns = columns == null
@@ -33,6 +34,28 @@ public class TablePrimaryKey {
         this.autoGenerate = autoGenerate;
     }
 
+    public boolean containsColumn(TableColumn column) {
+        for (TableColumn tableColumn : columns) {
+            if (Objects.equals(tableColumn.getName(), column.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
 
+    public List<TableColumn> getColumns() {
+        return columns;
+    }
+
+    public boolean isAutoGenerate() {
+        return autoGenerate;
+    }
+
+    public boolean isComposePrimary() {
+        if (columns.isEmpty()) {
+            return false;
+        }
+        return columns.size() != 1;
+    }
 }
 


### PR DESCRIPTION
Details:
- feat: add `SQLiteDialectProvider` class to implement `DialectProvider` interface for SQLite.
- feat: modified `MySQLDialectProvider` class's implementation.
- docs: updates `@PrimaryKey` docs.